### PR TITLE
Fix for Npm install error: pathspec '4.0'

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "del": "^3.0.0",
     "dotenv": "^5.0.1",
     "fancy-log": "^1.3.2",
-    "gulp": "git://github.com/gulpjs/gulp#4.0",
+    "gulp": "4.0",
     "gulp-concat": "^2.6.1",
     "gulp-ejs": "^3.1.2",
     "gulp-nodemon": "^2.2.1",


### PR DESCRIPTION
Trying to run npm i resulted in an error, while googling a bit, found the solution here.
https://github.com/olefredrik/FoundationPress/issues/1312