### PR TITLE
Fix path to background image

### DIFF
--- a/src/theme/sass/components/_hero.scss
+++ b/src/theme/sass/components/_hero.scss
@@ -1,7 +1,7 @@
 .hero{
 	position: relative;
 	width: 100%;
-	background-image: url("../images/evie_default_bg.jpeg");
+	background-image: url("../assets/images/evie_default_bg.jpeg");
 	box-shadow: $hero-shadow;
 	background-size: cover; 
 	background-position: center center;


### PR DESCRIPTION
The path to the image for the hero component is incorrect. The image folder is inside of the assets folder. This pull request fixes this. If it isn't fixed, tools like `webpack` will error when the path to the image isn't loaded.

https://github.com/anges244/evie/blob/69193d521dae58183a8f91966a2804f768034287/src/theme/sass/components/_hero.scss#L4